### PR TITLE
Add Financial Summary wizard

### DIFF
--- a/addons/account_financial_summary/README.md
+++ b/addons/account_financial_summary/README.md
@@ -1,0 +1,1 @@
+This module provides a simple wizard to quickly generate a financial summary of the general ledger. Users select a date range and the wizard aggregates the debit, credit and balance per account in one view.

--- a/addons/account_financial_summary/__init__.py
+++ b/addons/account_financial_summary/__init__.py
@@ -1,0 +1,1 @@
+from . import wizard

--- a/addons/account_financial_summary/__manifest__.py
+++ b/addons/account_financial_summary/__manifest__.py
@@ -1,0 +1,13 @@
+{
+    'name': 'Financial Summary Reports',
+    'version': '1.0',
+    'category': 'Accounting',
+    'summary': 'Quick summary for ledger and balance reports',
+    'depends': ['account'],
+    'data': [
+        'security/ir.model.access.csv',
+        'views/financial_summary_views.xml',
+    ],
+    'installable': True,
+    'license': 'LGPL-3',
+}

--- a/addons/account_financial_summary/security/ir.model.access.csv
+++ b/addons/account_financial_summary/security/ir.model.access.csv
@@ -1,0 +1,3 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_account_financial_summary_wizard,account.financial.summary.wizard,model_account_financial_summary_wizard,account.group_account_user,1,1,1,1
+access_account_financial_summary_line,account.financial.summary.line,model_account_financial_summary_line,account.group_account_user,1,1,1,1

--- a/addons/account_financial_summary/views/financial_summary_views.xml
+++ b/addons/account_financial_summary/views/financial_summary_views.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="view_account_financial_summary_wizard" model="ir.ui.view">
+        <field name="name">account.financial.summary.wizard.form</field>
+        <field name="model">account.financial.summary.wizard</field>
+        <field name="arch" type="xml">
+            <form string="Financial Summary">
+                <group>
+                    <field name="company_id"/>
+                    <field name="date_from"/>
+                    <field name="date_to"/>
+                </group>
+                <footer>
+                    <button string="Generate" type="object" name="action_generate" class="oe_highlight"/>
+                    <button string="Cancel" class="btn-secondary" special="cancel"/>
+                </footer>
+            </form>
+        </field>
+    </record>
+
+    <record id="view_account_financial_summary_line_tree" model="ir.ui.view">
+        <field name="name">account.financial.summary.line.tree</field>
+        <field name="model">account.financial.summary.line</field>
+        <field name="arch" type="xml">
+            <tree string="Summary">
+                <field name="account_id"/>
+                <field name="debit"/>
+                <field name="credit"/>
+                <field name="balance"/>
+            </tree>
+        </field>
+    </record>
+
+    <record id="action_account_financial_summary_wizard" model="ir.actions.act_window">
+        <field name="name">Financial Summary</field>
+        <field name="res_model">account.financial.summary.wizard</field>
+        <field name="view_mode">form</field>
+        <field name="target">new</field>
+    </record>
+
+    <menuitem id="menu_action_financial_summary" name="Financial Summary" parent="account.menu_finance_reports" action="action_account_financial_summary_wizard" sequence="100"/>
+</odoo>

--- a/addons/account_financial_summary/wizard/__init__.py
+++ b/addons/account_financial_summary/wizard/__init__.py
@@ -1,0 +1,1 @@
+from . import financial_summary_wizard

--- a/addons/account_financial_summary/wizard/financial_summary_wizard.py
+++ b/addons/account_financial_summary/wizard/financial_summary_wizard.py
@@ -1,0 +1,64 @@
+from odoo import api, fields, models
+
+
+class AccountFinancialSummaryWizard(models.TransientModel):
+    _name = 'account.financial.summary.wizard'
+    _description = 'Financial Summary Wizard'
+    _check_company_auto = True
+
+    company_id = fields.Many2one(
+        'res.company',
+        default=lambda self: self.env.company,
+        readonly=True
+    )
+    date_from = fields.Date(required=True, default=fields.Date.context_today)
+    date_to = fields.Date(required=True, default=fields.Date.context_today)
+    line_ids = fields.One2many('account.financial.summary.line', 'wizard_id')
+
+    def action_generate(self):
+        self.ensure_one()
+        self.line_ids.unlink()
+        query = """
+            SELECT account_id, SUM(debit) AS debit, SUM(credit) AS credit
+            FROM account_move_line
+            WHERE company_id = %s AND date >= %s AND date <= %s AND parent_state = 'posted'
+            GROUP BY account_id
+        """
+        params = (self.company_id.id, self.date_from, self.date_to)
+        self.env.cr.execute(query, params)
+        results = self.env.cr.fetchall()
+        lines = []
+        for account_id, debit, credit in results:
+            lines.append((0, 0, {
+                'account_id': account_id,
+                'debit': debit,
+                'credit': credit,
+                'balance': debit - credit,
+            }))
+        self.line_ids = lines
+        return {
+            'type': 'ir.actions.act_window',
+            'name': 'Financial Summary',
+            'res_model': 'account.financial.summary.line',
+            'view_mode': 'tree',
+            'target': 'new',
+            'domain': [('wizard_id', '=', self.id)],
+        }
+
+
+class AccountFinancialSummaryLine(models.TransientModel):
+    _name = 'account.financial.summary.line'
+    _description = 'Financial Summary Line'
+    _order = 'account_id'
+
+    wizard_id = fields.Many2one('account.financial.summary.wizard', ondelete='cascade')
+    account_id = fields.Many2one('account.account', readonly=True)
+    debit = fields.Monetary(currency_field='currency_id', readonly=True)
+    credit = fields.Monetary(currency_field='currency_id', readonly=True)
+    balance = fields.Monetary(currency_field='currency_id', readonly=True)
+    currency_id = fields.Many2one(
+        'res.currency',
+        related='wizard_id.company_id.currency_id',
+        readonly=True
+    )
+


### PR DESCRIPTION
## Summary
- add a new module `account_financial_summary`
- implement a wizard that aggregates debit, credit and balance per account
- expose a menu item under Accounting > Reporting

## Testing
- `python -m py_compile addons/account_financial_summary/**/*.py`

------
https://chatgpt.com/codex/tasks/task_e_683fb1a6ec448331a179b8b4e7064d92