### PR TITLE
Add XLSX export option to financial summary

### DIFF
--- a/addons/account_financial_summary/README.md
+++ b/addons/account_financial_summary/README.md
@@ -1,0 +1,10 @@
+This module adds a wizard under *Accounting > Reporting* that summarises accounting data with a single click. Depending on the chosen report type the wizard can:
+
+* Aggregate debit and credit per account (Libro Mayor).
+* Show open balances per partner (Estado de Cuentas).
+* Summarise debits and credits per account group (Balance General).
+
+The wizard works on posted journal items of the selected company and date range.
+
+The results can also be exported to Excel directly from the wizard form.
+

--- a/addons/account_financial_summary/__init__.py
+++ b/addons/account_financial_summary/__init__.py
@@ -1,0 +1,1 @@
+from . import wizard

--- a/addons/account_financial_summary/__manifest__.py
+++ b/addons/account_financial_summary/__manifest__.py
@@ -1,0 +1,13 @@
+{
+    'name': 'Financial Summary Reports',
+    'version': '1.2',
+    'category': 'Accounting',
+    'summary': 'Quick summary for ledger, partner balance and balance sheet',
+    'depends': ['account'],
+    'data': [
+        'security/ir.model.access.csv',
+        'views/financial_summary_views.xml',
+    ],
+    'installable': True,
+    'license': 'LGPL-3',
+}

--- a/addons/account_financial_summary/security/ir.model.access.csv
+++ b/addons/account_financial_summary/security/ir.model.access.csv
@@ -1,0 +1,3 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_account_financial_summary_wizard,account.financial.summary.wizard,model_account_financial_summary_wizard,account.group_account_user,1,1,1,1
+access_account_financial_summary_line,account.financial.summary.line,model_account_financial_summary_line,account.group_account_user,1,1,1,1

--- a/addons/account_financial_summary/views/financial_summary_views.xml
+++ b/addons/account_financial_summary/views/financial_summary_views.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="view_account_financial_summary_wizard" model="ir.ui.view">
+        <field name="name">account.financial.summary.wizard.form</field>
+        <field name="model">account.financial.summary.wizard</field>
+        <field name="arch" type="xml">
+            <form string="Financial Summary">
+                <group>
+                    <field name="company_id"/>
+                    <field name="date_from"/>
+                    <field name="date_to"/>
+                    <field name="report_type"/>
+                    <field name="partner_id" attrs="{'invisible': [('report_type', '!=', 'partner_balance')]}"/>
+                </group>
+                <footer>
+                    <button string="Generate" type="object" name="action_generate" class="oe_highlight"/>
+                    <button string="Export XLSX" type="object" name="action_export_xlsx" class="btn-secondary"/>
+                    <button string="Cancel" class="btn-secondary" special="cancel"/>
+                </footer>
+            </form>
+        </field>
+    </record>
+
+    <record id="view_account_financial_summary_line_tree" model="ir.ui.view">
+        <field name="name">account.financial.summary.line.tree</field>
+        <field name="model">account.financial.summary.line</field>
+        <field name="arch" type="xml">
+            <tree string="Summary" create="false" editable="false">
+                <field name="sequence" invisible="1"/>
+                <field name="label"/>
+                <field name="account_id"/>
+                <field name="partner_id"/>
+                <field name="debit"/>
+                <field name="credit"/>
+                <field name="balance"/>
+            </tree>
+        </field>
+    </record>
+
+    <record id="action_account_financial_summary_wizard" model="ir.actions.act_window">
+        <field name="name">Financial Summary</field>
+        <field name="res_model">account.financial.summary.wizard</field>
+        <field name="view_mode">form</field>
+        <field name="target">new</field>
+    </record>
+
+    <menuitem id="menu_action_financial_summary" name="Financial Summary" parent="account.menu_finance_reports" action="action_account_financial_summary_wizard" sequence="100"/>
+</odoo>

--- a/addons/account_financial_summary/wizard/__init__.py
+++ b/addons/account_financial_summary/wizard/__init__.py
@@ -1,0 +1,1 @@
+from . import financial_summary_wizard

--- a/addons/account_financial_summary/wizard/financial_summary_wizard.py
+++ b/addons/account_financial_summary/wizard/financial_summary_wizard.py
@@ -1,0 +1,153 @@
+from odoo import fields, models
+
+
+class AccountFinancialSummaryWizard(models.TransientModel):
+    _name = 'account.financial.summary.wizard'
+    _description = 'Financial Summary Wizard'
+    _check_company_auto = True
+
+    company_id = fields.Many2one(
+        'res.company',
+        default=lambda self: self.env.company,
+        readonly=True
+    )
+    date_from = fields.Date(required=True, default=fields.Date.context_today)
+    date_to = fields.Date(required=True, default=fields.Date.context_today)
+    report_type = fields.Selection([
+        ('ledger', 'Libro Mayor'),
+        ('partner_balance', 'Estado de Cuentas'),
+        ('balance_sheet', 'Balance General'),
+    ], default='ledger', required=True)
+    partner_id = fields.Many2one('res.partner')
+    line_ids = fields.One2many('account.financial.summary.line', 'wizard_id')
+    xls_file = fields.Binary()
+
+    def action_generate(self):
+        self.ensure_one()
+        self.line_ids.unlink()
+        if self.report_type == 'ledger':
+            query = """
+                SELECT account_id, SUM(debit) AS debit, SUM(credit) AS credit
+                FROM account_move_line
+                WHERE company_id = %s AND date >= %s AND date <= %s AND parent_state = 'posted'
+                GROUP BY account_id
+            """
+            params = (self.company_id.id, self.date_from, self.date_to)
+            self.env.cr.execute(query, params)
+            results = self.env.cr.fetchall()
+            lines = [
+                (0, 0, {
+                    'account_id': account_id,
+                    'label': self.env['account.account'].browse(account_id).display_name,
+                    'debit': debit,
+                    'credit': credit,
+                    'balance': debit - credit,
+                })
+                for account_id, debit, credit in results
+            ]
+        elif self.report_type == 'partner_balance':
+            query = """
+                SELECT partner_id, SUM(debit) AS debit, SUM(credit) AS credit
+                FROM account_move_line
+                WHERE company_id = %s AND date >= %s AND date <= %s AND parent_state = 'posted' %s
+                GROUP BY partner_id
+            """
+            extra = ''
+            params = [self.company_id.id, self.date_from, self.date_to]
+            if self.partner_id:
+                extra = 'AND partner_id = %s'
+                params.append(self.partner_id.id)
+            self.env.cr.execute(query % extra, tuple(params))
+            results = self.env.cr.fetchall()
+            lines = [
+                (0, 0, {
+                    'partner_id': partner_id,
+                    'label': self.env['res.partner'].browse(partner_id).display_name,
+                    'debit': debit,
+                    'credit': credit,
+                    'balance': debit - credit,
+                })
+                for partner_id, debit, credit in results
+            ]
+        else:  # balance_sheet
+            query = """
+                SELECT aa.internal_group, SUM(l.debit) AS debit, SUM(l.credit) AS credit
+                FROM account_move_line l
+                JOIN account_account aa ON l.account_id = aa.id
+                WHERE l.company_id = %s AND l.date >= %s AND l.date <= %s AND l.parent_state = 'posted'
+                GROUP BY aa.internal_group
+            """
+            params = (self.company_id.id, self.date_from, self.date_to)
+            self.env.cr.execute(query, params)
+            results = self.env.cr.fetchall()
+            group_labels = dict(self.env['account.account'].fields_get()['internal_group']['selection'])
+            lines = [
+                (0, 0, {
+                    'label': group_labels.get(group) or group,
+                    'debit': debit,
+                    'credit': credit,
+                    'balance': debit - credit,
+                })
+                for group, debit, credit in results
+            ]
+        self.line_ids = lines
+        return {
+            'type': 'ir.actions.act_window',
+            'name': 'Financial Summary',
+            'res_model': 'account.financial.summary.line',
+            'view_mode': 'tree',
+            'target': 'new',
+            'domain': [('wizard_id', '=', self.id)],
+        }
+
+    def action_export_xlsx(self):
+        self.ensure_one()
+        if not self.line_ids:
+            self.action_generate()
+        import base64
+        import io
+        from odoo.tools.misc import xlsxwriter
+
+        buffer = io.BytesIO()
+        workbook = xlsxwriter.Workbook(buffer, {'in_memory': True})
+        worksheet = workbook.add_worksheet()
+
+        headers = ['Label', 'Debit', 'Credit', 'Balance']
+        worksheet.write_row(0, 0, headers)
+        for row, line in enumerate(self.line_ids, start=1):
+            worksheet.write(row, 0, line.label)
+            worksheet.write_number(row, 1, line.debit)
+            worksheet.write_number(row, 2, line.credit)
+            worksheet.write_number(row, 3, line.balance)
+        workbook.close()
+        buffer.seek(0)
+        self.xls_file = base64.b64encode(buffer.getvalue())
+        return {
+            'type': 'ir.actions.act_url',
+            'target': 'self',
+            'url': (
+                '/web/content?model=account.financial.summary.wizard&field=xls_file'
+                '&download=true&filename=Financial_Summary.xlsx&id=%d' % self.id
+            ),
+        }
+
+
+class AccountFinancialSummaryLine(models.TransientModel):
+    _name = 'account.financial.summary.line'
+    _description = 'Financial Summary Line'
+    _order = 'sequence'
+
+    sequence = fields.Integer()
+    wizard_id = fields.Many2one('account.financial.summary.wizard', ondelete='cascade')
+    account_id = fields.Many2one('account.account', readonly=True)
+    partner_id = fields.Many2one('res.partner', readonly=True)
+    label = fields.Char(readonly=True)
+    debit = fields.Monetary(currency_field='currency_id', readonly=True)
+    credit = fields.Monetary(currency_field='currency_id', readonly=True)
+    balance = fields.Monetary(currency_field='currency_id', readonly=True)
+    currency_id = fields.Many2one(
+        'res.currency',
+        related='wizard_id.company_id.currency_id',
+        readonly=True
+    )
+


### PR DESCRIPTION
## Summary
- allow wizard to export lines to an Excel file
- expose an Export XLSX button in the wizard form
- document the new option in the README
- bump module version to 1.2

## Testing
- `python -m py_compile addons/account_financial_summary/**/*.py`

------
https://chatgpt.com/codex/tasks/task_e_683fb1a6ec448331a179b8b4e7064d92