### PR TITLE
Add custom ERP module for NCF handling

### DIFF
--- a/custom_addons/custom_erp/README.rst
+++ b/custom_addons/custom_erp/README.rst
@@ -1,0 +1,17 @@
+Custom ERP Extension
+====================
+
+This module provides an example of extending Odoo 18 Community
+with Dominican fiscal requirements and basic business features. It
+follows the OCA guidelines of modularity and clean code.
+
+Features
+--------
+* Adds a checkbox on quotations to indicate whether a NCF should be
+  generated.
+* Adds an optional NCF field on invoices.
+* Adds a checkbox in the Point of Sale configuration to require NCF.
+* Placeholder hooks for purchases and payroll integration.
+
+The module depends only on community editions of core apps and can be
+installed alongside standard Odoo modules.

--- a/custom_addons/custom_erp/__init__.py
+++ b/custom_addons/custom_erp/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/custom_addons/custom_erp/__manifest__.py
+++ b/custom_addons/custom_erp/__manifest__.py
@@ -1,0 +1,21 @@
+{
+    'name': 'Custom ERP Extension',
+    'summary': 'Sales, Accounting, Purchase, and optional Payroll tools',
+    'version': '16.0.1.0.0',
+    'category': 'Extra Tools',
+    'author': 'Your Company',
+    'license': 'LGPL-3',
+    'depends': [
+        'sale_management',
+        'account',
+        'purchase',
+        'stock',
+        'point_of_sale',
+        'hr',
+    ],
+    'data': [
+        # Data files, views, security, etc.
+    ],
+    'installable': True,
+    'application': False,
+}

--- a/custom_addons/custom_erp/models/__init__.py
+++ b/custom_addons/custom_erp/models/__init__.py
@@ -1,0 +1,4 @@
+from . import sale_order
+from . import account_move
+from . import purchase_order
+from . import pos_session

--- a/custom_addons/custom_erp/models/account_move.py
+++ b/custom_addons/custom_erp/models/account_move.py
@@ -1,0 +1,10 @@
+from odoo import fields, models
+
+
+class AccountMove(models.Model):
+    _inherit = 'account.move'
+
+    ncf_number = fields.Char(
+        string='NCF',
+        help='Fiscal receipt number.'
+    )

--- a/custom_addons/custom_erp/models/pos_session.py
+++ b/custom_addons/custom_erp/models/pos_session.py
@@ -1,0 +1,10 @@
+from odoo import fields, models
+
+
+class PosConfig(models.Model):
+    _inherit = 'pos.config'
+
+    ncf_required = fields.Boolean(
+        string='Add NCF in POS',
+        help='Enable NCF field in POS orders.'
+    )

--- a/custom_addons/custom_erp/models/purchase_order.py
+++ b/custom_addons/custom_erp/models/purchase_order.py
@@ -1,0 +1,8 @@
+from odoo import models
+
+
+class PurchaseOrder(models.Model):
+    _inherit = 'purchase.order'
+
+    # Placeholder for custom purchase logic
+    pass

--- a/custom_addons/custom_erp/models/sale_order.py
+++ b/custom_addons/custom_erp/models/sale_order.py
@@ -1,0 +1,10 @@
+from odoo import fields, models
+
+
+class SaleOrder(models.Model):
+    _inherit = 'sale.order'
+
+    ncf_required = fields.Boolean(
+        string='Add NCF',
+        help='Check if this order requires a NCF reference.'
+    )


### PR DESCRIPTION
## Summary
- create `custom_addons` directory
- add `custom_erp` module with example Dominican NCF fields

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6883e8a3b4148331b5e19920cbadceb4