### PR TITLE
Add DGII NCF Manager module

### DIFF
--- a/custom_addons/dgii_ncf_manager/README.rst
+++ b/custom_addons/dgii_ncf_manager/README.rst
@@ -1,0 +1,7 @@
+DGII NCF Manager
+================
+
+Este módulo gestiona los rangos de NCF (comprobantes fiscales) otorgados
+por la Dirección General de Impuestos Internos de República Dominicana.
+Se integra con las facturas para asignar automáticamente los números de
+comprobante según el rango activo configurado en el diario.

--- a/custom_addons/dgii_ncf_manager/__init__.py
+++ b/custom_addons/dgii_ncf_manager/__init__.py
@@ -1,0 +1,2 @@
+from . import models
+from . import wizard

--- a/custom_addons/dgii_ncf_manager/__manifest__.py
+++ b/custom_addons/dgii_ncf_manager/__manifest__.py
@@ -1,0 +1,26 @@
+{
+    'name': 'DGII NCF Manager',
+    'version': '1.0.0',
+    'summary': 'Gestión de rangos de NCF otorgados por la DGII',
+    'category': 'Accounting',
+    'author': 'Your Company',
+    'description': 'Módulo para administrar rangos de comprobantes fiscales de la DGII y asignarlos a las facturas.',
+    'license': 'LGPL-3',
+    'depends': [
+        'account',
+        'custom_erp'
+    ],
+    'data': [
+        'security/dgii_ncf_security.xml',
+        'security/ir.model.access.csv',
+        'views/ncf_range_views.xml',
+        'views/account_journal_views.xml',
+        'wizard/import_ncf_wizard_views.xml',
+        'report/ncf_range_report.xml',
+        'report/ncf_range_templates.xml',
+        'data/cron.xml',
+    ],
+    'installable': True,
+    'application': True,
+    'auto_install': False,
+}

--- a/custom_addons/dgii_ncf_manager/data/cron.xml
+++ b/custom_addons/dgii_ncf_manager/data/cron.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="ir_cron_ncf_expiration" model="ir.cron">
+        <field name="name">NCF Range Expiration</field>
+        <field name="model_id" ref="model_ncf_range"/>
+        <field name="state">code</field>
+        <field name="code">model._cron_check_expiration()</field>
+        <field name="interval_number">1</field>
+        <field name="interval_type">days</field>
+        <field name="numbercall">-1</field>
+        <field name="active">True</field>
+    </record>
+</odoo>

--- a/custom_addons/dgii_ncf_manager/models/__init__.py
+++ b/custom_addons/dgii_ncf_manager/models/__init__.py
@@ -1,0 +1,3 @@
+from . import ncf_range
+from . import account_journal
+from . import account_move

--- a/custom_addons/dgii_ncf_manager/models/account_journal.py
+++ b/custom_addons/dgii_ncf_manager/models/account_journal.py
@@ -1,0 +1,21 @@
+from odoo import fields, models
+
+
+# Extiende el diario contable para definir el uso de NCF
+class AccountJournal(models.Model):
+    _inherit = 'account.journal'
+
+    # Indica si el diario debe generar NCF
+    usar_ncf = fields.Boolean(string='Usar NCF')
+    # Tipo de NCF que utilizará por defecto este diario
+    default_ncf_type = fields.Selection(
+        selection=[
+            ('B01', 'B01'),
+            ('B02', 'B02'),
+            ('B03', 'B03'),
+            ('B04', 'B04'),
+            ('E31', 'E31'),
+            ('E32', 'E32'),
+        ],
+        string='Tipo de NCF'
+    )

--- a/custom_addons/dgii_ncf_manager/models/account_move.py
+++ b/custom_addons/dgii_ncf_manager/models/account_move.py
@@ -1,0 +1,33 @@
+from odoo import api, models, _
+from odoo.exceptions import ValidationError
+
+
+class AccountMove(models.Model):
+    _inherit = 'account.move'
+
+    @api.model
+    def create(self, vals):
+        move = super().create(vals)
+        # Asignar NCF al crear la factura si el diario lo requiere
+        if move.move_type == 'out_invoice' and move.journal_id.usar_ncf:
+            ncf_type = move.journal_id.default_ncf_type
+            ncf_range = self.env['ncf.range'].search([
+                ('ncf_type', '=', ncf_type),
+                ('state', '=', 'active')
+            ], order='sequence_start', limit=1)
+            if not ncf_range:
+                raise ValidationError(
+                    _('No existe un rango de NCF disponible para el tipo %s.') % ncf_type)
+            ncf = ncf_range.assign_ncf()
+            if not ncf:
+                raise ValidationError(_('El rango de NCF está agotado.'))
+            move.ncf_number = ncf
+        return move
+
+    def action_post(self):
+        # Validar que la factura tenga un NCF antes de publicarla
+        for move in self:
+            if move.journal_id.usar_ncf:
+                if not move.ncf_number:
+                    raise ValidationError(_('La factura requiere un NCF válido.'))
+        return super().action_post()

--- a/custom_addons/dgii_ncf_manager/models/ncf_range.py
+++ b/custom_addons/dgii_ncf_manager/models/ncf_range.py
@@ -1,0 +1,97 @@
+from odoo import api, fields, models, _
+from odoo.exceptions import ValidationError
+
+
+# Modelo para manejar los rangos de NCF otorgados por la DGII
+class NCFRange(models.Model):
+    _name = 'ncf.range'
+    _description = 'Rango de NCF'
+    _order = 'ncf_type, sequence_start'
+
+    name = fields.Char(required=True)
+    ncf_type = fields.Selection([
+        ('B01', 'B01 - Factura de Cr\u00e9dito Fiscal'),
+        ('B02', 'B02 - Factura de Consumo'),
+        ('B03', 'B03 - Reg\u00edmenes Especiales'),
+        ('B04', 'B04 - Gasto Menor'),
+        ('E31', 'E31 - e-CF Factura de Cr\u00e9dito Fiscal'),
+        ('E32', 'E32 - e-CF Factura de Consumo'),
+    ], required=True)
+    sequence_start = fields.Char(required=True)
+    sequence_end = fields.Char(required=True)
+    expiration_date = fields.Date(required=True)
+    current_ncf = fields.Char()
+    state = fields.Selection([
+        ('draft', 'Borrador'),
+        ('active', 'Activo'),
+        ('exhausted', 'Agotado'),
+        ('expired', 'Vencido'),
+    ], default='draft', compute='_compute_state', store=True)
+
+    @api.constrains('sequence_start', 'sequence_end', 'ncf_type')
+    def _check_overlap(self):
+        """Evita solapamiento entre rangos activos del mismo tipo."""
+        for rec in self:
+            overlaps = self.search([
+                ('id', '!=', rec.id),
+                ('ncf_type', '=', rec.ncf_type),
+                ('state', 'in', ['draft', 'active']),
+                ('sequence_start', '<=', rec.sequence_end),
+                ('sequence_end', '>=', rec.sequence_start),
+            ], limit=1)
+            if overlaps:
+                raise ValidationError(_('El rango de NCF se solapa con otro rango activo.'))
+
+    @api.depends('expiration_date', 'current_ncf')
+    def _compute_state(self):
+        """Calcula el estado del rango según la fecha y el NCF actual."""
+        today = fields.Date.today()
+        for rec in self:
+            if rec.expiration_date and rec.expiration_date < today:
+                rec.state = 'expired'
+            elif rec.current_ncf and rec.current_ncf > rec.sequence_end:
+                rec.state = 'exhausted'
+            elif rec.current_ncf:
+                rec.state = 'active'
+            else:
+                rec.state = 'draft'
+
+    def action_activate(self):
+        """Activa el rango y coloca el NCF inicial."""
+        for rec in self:
+            rec.current_ncf = rec.sequence_start
+            rec.state = 'active'
+
+    def _get_next_ncf(self):
+        """Calcula el próximo NCF del rango."""
+        self.ensure_one()
+        if not self.current_ncf:
+            next_ncf = self.sequence_start
+        else:
+            prefix = self.current_ncf[:3]
+            number = int(self.current_ncf[3:])
+            next_num = number + 1
+            next_ncf = prefix + str(next_num).zfill(len(self.current_ncf) - 3)
+        if next_ncf > self.sequence_end:
+            self.state = 'exhausted'
+            return None
+        self.current_ncf = next_ncf
+        self._compute_state()
+        return next_ncf
+
+    def assign_ncf(self):
+        """Entrega un NCF y avanza la secuencia."""
+        self.ensure_one()
+        if self.state != 'active':
+            raise ValidationError(_('El rango de NCF no está activo.'))
+        ncf = self.current_ncf or self.sequence_start
+        next_ncf = self._get_next_ncf()
+        if not next_ncf:
+            ncf = None
+        return ncf
+
+    @api.model
+    def _cron_check_expiration(self):
+        """Tarea programada que actualiza el estado de los rangos."""
+        for rec in self.search([('state', 'in', ['draft', 'active'])]):
+            rec._compute_state()

--- a/custom_addons/dgii_ncf_manager/report/ncf_range_report.xml
+++ b/custom_addons/dgii_ncf_manager/report/ncf_range_report.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="action_ncf_range_report" model="ir.actions.report">
+        <field name="name">Reporte de Rangos NCF</field>
+        <field name="model">ncf.range</field>
+        <field name="report_type">qweb-pdf</field>
+        <field name="report_name">dgii_ncf_manager.ncf_range_report_template</field>
+    </record>
+</odoo>

--- a/custom_addons/dgii_ncf_manager/report/ncf_range_templates.xml
+++ b/custom_addons/dgii_ncf_manager/report/ncf_range_templates.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <template id="ncf_range_report_template">
+        <t t-call="web.basic_layout">
+            <t t-set="o" t-value="docs[0]"/>
+            <div class="page">
+                <h2>Rango NCF: <t t-esc="o.name"/></h2>
+                <p>Tipo: <t t-esc="o.ncf_type"/></p>
+                <p>Inicio: <t t-esc="o.sequence_start"/> - Fin: <t t-esc="o.sequence_end"/></p>
+                <p>Actual: <t t-esc="o.current_ncf"/></p>
+                <p>Vence: <t t-esc="o.expiration_date"/></p>
+            </div>
+        </t>
+    </template>
+</odoo>

--- a/custom_addons/dgii_ncf_manager/security/dgii_ncf_security.xml
+++ b/custom_addons/dgii_ncf_manager/security/dgii_ncf_security.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="group_fiscal_manager" model="res.groups">
+        <field name="name">Gestor Fiscal</field>
+        <field name="category_id" ref="base.module_category_accounting"/>
+    </record>
+</odoo>

--- a/custom_addons/dgii_ncf_manager/security/ir.model.access.csv
+++ b/custom_addons/dgii_ncf_manager/security/ir.model.access.csv
@@ -1,0 +1,4 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+ncf_range_manager_all,NCF Range Manager,model_ncf_range,dgii_ncf_manager.group_fiscal_manager,1,1,1,1
+ncf_range_user,NCF Range User,model_ncf_range,base.group_user,1,0,0,0
+import_ncf_wizard,Import NCF Wizard,model_import_ncf_wizard,dgii_ncf_manager.group_fiscal_manager,1,1,1,1

--- a/custom_addons/dgii_ncf_manager/views/account_journal_views.xml
+++ b/custom_addons/dgii_ncf_manager/views/account_journal_views.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="view_account_journal_form_inherit_ncf" model="ir.ui.view">
+        <field name="name">account.journal.form.ncf</field>
+        <field name="model">account.journal</field>
+        <field name="inherit_id" ref="account.view_account_journal_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//group/group" position="inside">
+                <field name="usar_ncf"/>
+                <field name="default_ncf_type" attrs="{'invisible': [('usar_ncf','=',False)]}"/>
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/custom_addons/dgii_ncf_manager/views/ncf_range_views.xml
+++ b/custom_addons/dgii_ncf_manager/views/ncf_range_views.xml
@@ -69,5 +69,5 @@
     </record>
 
     <menuitem id="menu_dgii_ncf_root" name="DGII" sequence="60" groups="dgii_ncf_manager.group_fiscal_manager"/>
-    <menuitem id="menu_ncf_range" name="Rangos de NCF" parent="menu_dgii_ncf_root" action="action_ncf_range"/>
+    <menuitem id="menu_ncf_range" name="Rangos de NCF" parent="menu_dgii_ncf_root" action="action_ncf_range" groups="dgii_ncf_manager.group_fiscal_manager"/>
 </odoo>

--- a/custom_addons/dgii_ncf_manager/views/ncf_range_views.xml
+++ b/custom_addons/dgii_ncf_manager/views/ncf_range_views.xml
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="view_ncf_range_tree" model="ir.ui.view">
+        <field name="name">ncf.range.tree</field>
+        <field name="model">ncf.range</field>
+        <field name="arch" type="xml">
+            <tree>
+                <field name="name"/>
+                <field name="ncf_type"/>
+                <field name="sequence_start"/>
+                <field name="sequence_end"/>
+                <field name="current_ncf"/>
+                <field name="expiration_date"/>
+                <field name="state"/>
+            </tree>
+        </field>
+    </record>
+
+    <record id="view_ncf_range_form" model="ir.ui.view">
+        <field name="name">ncf.range.form</field>
+        <field name="model">ncf.range</field>
+        <field name="arch" type="xml">
+            <form string="Rango de NCF">
+                <sheet>
+                    <group>
+                        <field name="name"/>
+                        <field name="ncf_type"/>
+                        <field name="sequence_start"/>
+                        <field name="sequence_end"/>
+                        <field name="current_ncf" readonly="1"/>
+                        <field name="expiration_date"/>
+                        <field name="state" readonly="1"/>
+                    </group>
+                </sheet>
+            </form>
+        </field>
+    </record>
+
+    <record id="ncf_range_kanban" model="ir.ui.view">
+        <field name="name">ncf.range.kanban</field>
+        <field name="model">ncf.range</field>
+        <field name="arch" type="xml">
+            <kanban class="o_kanban_small_columns">
+                <field name="name"/>
+                <field name="ncf_type"/>
+                <field name="current_ncf"/>
+                <field name="expiration_date"/>
+                <field name="state"/>
+                <templates>
+                    <t t-name="kanban-box">
+                        <div class="oe_kanban_global_click">
+                            <strong><field name="name"/></strong>
+                            <div><field name="ncf_type"/></div>
+                            <div>Actual: <field name="current_ncf"/></div>
+                            <div>Vence: <field name="expiration_date"/></div>
+                            <div><field name="state"/></div>
+                        </div>
+                    </t>
+                </templates>
+            </kanban>
+        </field>
+    </record>
+
+    <record id="action_ncf_range" model="ir.actions.act_window">
+        <field name="name">Rangos de NCF</field>
+        <field name="res_model">ncf.range</field>
+        <field name="view_mode">tree,form,kanban</field>
+        <field name="help">Administrar rangos de NCF de la DGII</field>
+    </record>
+
+    <menuitem id="menu_dgii_ncf_root" name="DGII" sequence="60" groups="dgii_ncf_manager.group_fiscal_manager"/>
+    <menuitem id="menu_ncf_range" name="Rangos de NCF" parent="menu_dgii_ncf_root" action="action_ncf_range"/>
+</odoo>

--- a/custom_addons/dgii_ncf_manager/wizard/__init__.py
+++ b/custom_addons/dgii_ncf_manager/wizard/__init__.py
@@ -1,0 +1,1 @@
+from . import import_ncf_wizard

--- a/custom_addons/dgii_ncf_manager/wizard/import_ncf_wizard.py
+++ b/custom_addons/dgii_ncf_manager/wizard/import_ncf_wizard.py
@@ -1,0 +1,29 @@
+import base64
+import csv
+import io
+
+from odoo import models, fields
+
+
+# Asistente para importar rangos de NCF desde un archivo CSV
+class ImportNCFWizard(models.TransientModel):
+    _name = 'import.ncf.wizard'
+    _description = 'Importar rangos de NCF'
+
+    file_data = fields.Binary(string='Archivo', required=True)
+    file_name = fields.Char(string='Nombre del archivo')
+
+    def action_import(self):
+        """Crea rangos de NCF a partir del archivo cargado."""
+        self.ensure_one()
+        data = base64.b64decode(self.file_data)
+        file_io = io.StringIO(data.decode())
+        reader = csv.DictReader(file_io)
+        for row in reader:
+            self.env['ncf.range'].create({
+                'name': row.get('name'),
+                'ncf_type': row.get('ncf_type'),
+                'sequence_start': row.get('sequence_start'),
+                'sequence_end': row.get('sequence_end'),
+                'expiration_date': row.get('expiration_date'),
+            })

--- a/custom_addons/dgii_ncf_manager/wizard/import_ncf_wizard_views.xml
+++ b/custom_addons/dgii_ncf_manager/wizard/import_ncf_wizard_views.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="view_import_ncf_wizard" model="ir.ui.view">
+        <field name="name">import.ncf.wizard.form</field>
+        <field name="model">import.ncf.wizard</field>
+        <field name="arch" type="xml">
+            <form string="Importar Rangos de NCF">
+                <group>
+                    <field name="file_data" filename="file_name"/>
+                    <field name="file_name"/>
+                </group>
+                <footer>
+                    <button string="Importar" type="object" name="action_import" class="btn-primary"/>
+                    <button string="Cancelar" class="btn-secondary" special="cancel"/>
+                </footer>
+            </form>
+        </field>
+    </record>
+
+    <record id="action_import_ncf_wizard" model="ir.actions.act_window">
+        <field name="name">Importar Rangos de NCF</field>
+        <field name="res_model">import.ncf.wizard</field>
+        <field name="view_mode">form</field>
+        <field name="target">new</field>
+    </record>
+
+    <menuitem id="menu_import_ncf" name="Importar Rangos" parent="menu_dgii_ncf_root" action="action_import_ncf_wizard"/>
+</odoo>

--- a/custom_addons/dgii_ncf_manager/wizard/import_ncf_wizard_views.xml
+++ b/custom_addons/dgii_ncf_manager/wizard/import_ncf_wizard_views.xml
@@ -24,5 +24,5 @@
         <field name="target">new</field>
     </record>
 
-    <menuitem id="menu_import_ncf" name="Importar Rangos" parent="menu_dgii_ncf_root" action="action_import_ncf_wizard"/>
+    <menuitem id="menu_import_ncf" name="Importar Rangos" parent="menu_dgii_ncf_root" action="action_import_ncf_wizard" groups="dgii_ncf_manager.group_fiscal_manager"/>
 </odoo>


### PR DESCRIPTION
## Summary
- add new `dgii_ncf_manager` module in custom_addons
- implement `ncf.range` model with expiration validation
- extend journals and invoices to manage Dominican NCF numbers
- provide wizard for importing ranges
- add cron job and basic views, menus, report, and Spanish comments

## Testing
- `python3 -m compileall custom_addons/dgii_ncf_manager`


------
https://chatgpt.com/codex/tasks/task_e_6883f55c27cc8331a7fd52860ee7d0f1