### PR TITLE
Prevent using expired NCF ranges

### DIFF
--- a/custom_addons/dgii_ncf_manager/models/ncf_range.py
+++ b/custom_addons/dgii_ncf_manager/models/ncf_range.py
@@ -76,6 +76,11 @@ class NCFRange(models.Model):
 
     def assign_ncf(self):
         self.ensure_one()
+        # Refresh the state in case the range expired since last computation
+        self._compute_state()
+        today = fields.Date.today()
+        if self.expiration_date and self.expiration_date < today:
+            raise ValidationError(_('NCF range has expired.'))
         if self.state != 'active':
             raise ValidationError(_('NCF range is not active.'))
         ncf = self.current_ncf or self.sequence_start

--- a/custom_addons/dgii_ncf_manager/tests/test_ncf_range.py
+++ b/custom_addons/dgii_ncf_manager/tests/test_ncf_range.py
@@ -1,0 +1,42 @@
+from datetime import timedelta
+
+from freezegun import freeze_time
+from odoo.exceptions import ValidationError
+from odoo.tests.common import TransactionCase
+from odoo import fields
+
+
+class TestNCFRange(TransactionCase):
+    def setUp(self):
+        super().setUp()
+        self.range = self.env['ncf.range'].create({
+            'name': 'Test Range',
+            'ncf_type': 'B01',
+            'sequence_start': 'B0100000001',
+            'sequence_end': 'B0100000010',
+            'expiration_date': fields.Date.today() + timedelta(days=1),
+        })
+        self.range.action_activate()
+        self.journal = self.env['account.journal'].create({
+            'name': 'NCF Journal',
+            'type': 'sale',
+            'code': 'NCF1',
+            'usar_ncf': True,
+            'default_ncf_type': 'B01',
+        })
+
+    @freeze_time((fields.Date.today() + timedelta(days=2)).strftime('%Y-%m-%d'))
+    def test_assign_ncf_expired(self):
+        with self.assertRaises(ValidationError):
+            self.range.assign_ncf()
+
+    @freeze_time((fields.Date.today() + timedelta(days=2)).strftime('%Y-%m-%d'))
+    def test_invoice_creation_blocked(self):
+        with self.assertRaises(ValidationError):
+            self.env['account.move'].create({
+                'move_type': 'out_invoice',
+                'journal_id': self.journal.id,
+                'partner_id': self.env['res.partner'].create({'name': 'P'}).id,
+                'invoice_line_ids': [(0, 0, {'name': 'l', 'price_unit': 10})],
+            })
+


### PR DESCRIPTION
## Summary
- recompute state before assigning NCFs and reject expired ranges
- add tests covering expired range behaviour

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `PGHOST=localhost ./odoo-bin --stop-after-init -i base --db-filter=test_db$ -d test_db --db_user=odoo --db_password=odoo --log-level=debug` *(fails: excessive resource usage)*

------
https://chatgpt.com/codex/tasks/task_e_688424c62ca88331affe1d2cc7b81bf6