### PR TITLE
Fix lint issues and wrap long strings

### DIFF
--- a/addons/l10n_it_edi_doi/__manifest__.py
+++ b/addons/l10n_it_edi_doi/__manifest__.py
@@ -7,11 +7,15 @@
         'l10n_it_edi',
         'sale',
     ],
-    'description': """
-    Add support for the Declaration of Intent (Dichiarazione di Intento) to the Italian localization.
-    """,
+    'description': (
+        'Add support for the Declaration of Intent (Dichiarazione di Intento) '
+        'to the Italian localization.'
+    ),
     'category': 'Accounting/Localizations',
-    'website': 'https://www.odoo.com/documentation/18.0/applications/finance/fiscal_localizations/italy.html',
+    'website': (
+        'https://www.odoo.com/documentation/18.0/applications/finance/'
+        'fiscal_localizations/italy.html'
+    ),
     'data': [
         'security/ir.model.access.csv',
         'data/invoice_it_template.xml',

--- a/addons/pos_account_tax_python/__init__.py
+++ b/addons/pos_account_tax_python/__init__.py
@@ -1,1 +1,2 @@
-from . import models
+# pylint: disable=unused-import
+from . import models  # noqa: F401

--- a/addons/pos_account_tax_python/__manifest__.py
+++ b/addons/pos_account_tax_python/__manifest__.py
@@ -4,7 +4,9 @@
     'name': "Allow custom taxes in POS",
     'category': 'Accounting/Accounting',
     'version': '1.0',
-    'description': """Add code to manage custom taxes to the POS assets bundle""",
+    'description': (
+        'Add code to manage custom taxes to the POS assets bundle'
+    ),
     'depends': ['account_tax_python', 'point_of_sale'],
     'assets': {
         'point_of_sale._assets_pos': [

--- a/addons/pos_account_tax_python/models/__init__.py
+++ b/addons/pos_account_tax_python/models/__init__.py
@@ -1,1 +1,2 @@
-from . import account_tax
+# pylint: disable=unused-import
+from . import account_tax  # noqa: F401

--- a/addons/pos_account_tax_python/models/account_tax.py
+++ b/addons/pos_account_tax_python/models/account_tax.py
@@ -6,4 +6,7 @@ class AccountTax(models.Model):
 
     @api.model
     def _load_pos_data_fields(self, config_id):
-        return super()._load_pos_data_fields(config_id) + ['formula_decoded_info']
+        return (
+            super()._load_pos_data_fields(config_id)
+            + ['formula_decoded_info']
+        )

--- a/addons/pos_restaurant/__init__.py
+++ b/addons/pos_restaurant/__init__.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from . import models
+# pylint: disable=unused-import
+from . import models  # noqa: F401

--- a/addons/pos_restaurant/__manifest__.py
+++ b/addons/pos_restaurant/__manifest__.py
@@ -10,10 +10,12 @@
     'summary': 'Restaurant extensions for the Point of Sale ',
     'description': """
 
-This module adds several features to the Point of Sale that are specific to restaurant management:
+This module adds several features to the Point of Sale that are
+specific to restaurant management:
 - Bill Printing: Allows you to print a receipt before the order is paid
 - Bill Splitting: Allows you to split an order into different orders
-- Kitchen Order Printing: allows you to print orders updates to kitchen or bar printers
+- Kitchen Order Printing: allows you to print orders updates to kitchen
+  or bar printers
 
 """,
     'depends': ['point_of_sale'],
@@ -32,7 +34,11 @@ This module adds several features to the Point of Sale that are specific to rest
     'assets': {
         'point_of_sale._assets_pos': [
             'pos_restaurant/static/src/**/*',
-            ('after', 'point_of_sale/static/src/scss/pos.scss', 'pos_restaurant/static/src/scss/restaurant.scss'),
+            (
+                'after',
+                'point_of_sale/static/src/scss/pos.scss',
+                'pos_restaurant/static/src/scss/restaurant.scss'
+            ),
         ],
         'web.assets_backend': [
             'point_of_sale/static/src/scss/pos_dashboard.scss',

--- a/addons/pos_restaurant/models/__init__.py
+++ b/addons/pos_restaurant/models/__init__.py
@@ -1,10 +1,11 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from . import pos_config
-from . import pos_order
-from . import pos_payment
-from . import pos_restaurant
-from . import pos_session
-from . import res_config_settings
-from . import account_fiscal_position
+# pylint: disable=unused-import
+from . import pos_config  # noqa: F401
+from . import pos_order  # noqa: F401
+from . import pos_payment  # noqa: F401
+from . import pos_restaurant  # noqa: F401
+from . import pos_session  # noqa: F401
+from . import res_config_settings  # noqa: F401
+from . import account_fiscal_position  # noqa: F401

--- a/addons/pos_self_order/__manifest__.py
+++ b/addons/pos_self_order/__manifest__.py
@@ -2,7 +2,10 @@
 {
     "name": "POS Self Order",
     'version': '1.0',
-    "summary": "Addon for the POS App that allows customers to view the menu on their smartphone.",
+    "summary": (
+        "Addon for the POS App that allows customers "
+        "to view the menu on their smartphone."
+    ),
     "category": "Sales/Point Of Sale",
     "depends": ["pos_restaurant", "http_routing"],
     "auto_install": ["pos_restaurant"],
@@ -48,7 +51,10 @@
             'web/static/lib/bootstrap/js/dist/base-component.js',
             "web/static/lib/bootstrap/js/dist/carousel.js",
             'web/static/lib/bootstrap/js/dist/scrollspy.js',
-            "point_of_sale/static/src/app/store/models/product_custom_attribute.js",
+            (
+                "point_of_sale/static/src/app/store/models/"
+                "product_custom_attribute.js"
+            ),
             'web_editor/static/src/js/editor/odoo-editor/src/base_style.scss',
             'web_editor/static/src/scss/web_editor.common.scss',
             "point_of_sale/static/src/app/generic_components/numpad/*",
@@ -66,7 +72,10 @@
             "pos_self_order/static/src/app/**/*",
             "point_of_sale/static/src/app/printer/hw_printer.js",
             "web/static/src/core/utils/render.js",
-            "pos_self_order/static/src/app/store/order_change_receipt_template.xml",
+            (
+                "pos_self_order/static/src/app/store/"
+                "order_change_receipt_template.xml"
+            ),
             "account/static/src/helpers/*.js",
             "web/static/src/views/fields/parsers.js",
 

--- a/addons/project_hr_expense/__init__.py
+++ b/addons/project_hr_expense/__init__.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from . import models
+# pylint: disable=unused-import
+from . import models  # noqa: F401

--- a/addons/project_hr_expense/__manifest__.py
+++ b/addons/project_hr_expense/__manifest__.py
@@ -7,7 +7,10 @@
     'version': '1.0',
     'category': 'Services/expenses',
     'summary': 'Project expenses',
-    'description': 'Bridge created to add the number of expenses linked to an AA to a project form',
+    'description': (
+        'Bridge created to add the number of expenses linked to an '
+        'AA to a project form'
+    ),
     'depends': ['project_account', 'hr_expense'],
     'data': [
         'views/project_project_views.xml',

--- a/addons/project_hr_expense/models/__init__.py
+++ b/addons/project_hr_expense/models/__init__.py
@@ -1,2 +1,3 @@
-from . import hr_expense
-from . import project_project
+# pylint: disable=unused-import
+from . import hr_expense  # noqa: F401
+from . import project_project  # noqa: F401

--- a/addons/project_hr_expense/tests/__init__.py
+++ b/addons/project_hr_expense/tests/__init__.py
@@ -1,4 +1,5 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from . import test_analytics
-from . import test_project_profitability
+# pylint: disable=unused-import
+from . import test_analytics  # noqa: F401
+from . import test_project_profitability  # noqa: F401

--- a/custom_addons/custom_erp/__init__.py
+++ b/custom_addons/custom_erp/__init__.py
@@ -1,1 +1,2 @@
-from . import models
+# pylint: disable=unused-import
+from . import models  # noqa: F401

--- a/custom_addons/custom_erp/models/__init__.py
+++ b/custom_addons/custom_erp/models/__init__.py
@@ -1,4 +1,5 @@
-from . import sale_order
-from . import account_move
-from . import purchase_order
-from . import pos_session
+# pylint: disable=unused-import
+from . import sale_order  # noqa: F401
+from . import account_move  # noqa: F401
+from . import purchase_order  # noqa: F401
+from . import pos_session  # noqa: F401

--- a/custom_addons/dgii_ncf_manager/__init__.py
+++ b/custom_addons/dgii_ncf_manager/__init__.py
@@ -1,2 +1,3 @@
-from . import models
-from . import wizard
+# pylint: disable=unused-import
+from . import models  # noqa: F401
+from . import wizard  # noqa: F401

--- a/custom_addons/dgii_ncf_manager/models/__init__.py
+++ b/custom_addons/dgii_ncf_manager/models/__init__.py
@@ -1,3 +1,4 @@
-from . import ncf_range
-from . import account_journal
-from . import account_move
+# pylint: disable=unused-import
+from . import ncf_range  # noqa: F401
+from . import account_journal  # noqa: F401
+from . import account_move  # noqa: F401

--- a/custom_addons/dgii_ncf_manager/models/ncf_range.py
+++ b/custom_addons/dgii_ncf_manager/models/ncf_range.py
@@ -38,7 +38,9 @@ class NCFRange(models.Model):
                 ('sequence_end', '>=', rec.sequence_start),
             ], limit=1)
             if overlaps:
-                raise ValidationError(_('NCF range overlaps with existing range.'))
+                raise ValidationError(
+                    _('NCF range overlaps with existing range.')
+                )
 
     @api.depends('expiration_date', 'current_ncf')
     def _compute_state(self):

--- a/custom_addons/dgii_ncf_manager/wizard/__init__.py
+++ b/custom_addons/dgii_ncf_manager/wizard/__init__.py
@@ -1,1 +1,2 @@
-from . import import_ncf_wizard
+# pylint: disable=unused-import
+from . import import_ncf_wizard  # noqa: F401


### PR DESCRIPTION
## Summary
- wrap long strings in several manifests
- add pylint and flake8 hints for registration imports
- split validation error message in NCF range model
- split long return line in account tax model

## Testing
- `flake8 custom_addons addons/pos_self_order/__manifest__.py addons/l10n_it_edi_doi/__manifest__.py addons/project_hr_expense/__manifest__.py addons/pos_restaurant/__manifest__.py addons/pos_account_tax_python/__manifest__.py addons/pos_account_tax_python/models/account_tax.py addons/pos_account_tax_python/__init__.py addons/pos_account_tax_python/models/__init__.py addons/pos_restaurant/__init__.py addons/pos_restaurant/models/__init__.py addons/project_hr_expense/__init__.py addons/project_hr_expense/models/__init__.py addons/project_hr_expense/tests/__init__.py`

------
https://chatgpt.com/codex/tasks/task_e_688424ce06988331974f735a7bd1bc8b