### PR TITLE
Remove custom_erp dependency

### DIFF
--- a/custom_addons/dgii_ncf_manager/__manifest__.py
+++ b/custom_addons/dgii_ncf_manager/__manifest__.py
@@ -6,8 +6,7 @@
     'author': 'Your Company',
     'license': 'LGPL-3',
     'depends': [
-        'account',
-        'custom_erp'
+        'account'
     ],
     'data': [
         'security/dgii_ncf_security.xml',
@@ -20,5 +19,5 @@
         'data/cron.xml',
     ],
     'installable': True,
-    'application': False,
+    'application': True,
 }


### PR DESCRIPTION
## Summary
- allow dgii_ncf_manager to install without `custom_erp`
- mark dgii_ncf_manager as an application module

## Testing
- `python3 -m compileall custom_addons/dgii_ncf_manager`

------
https://chatgpt.com/codex/tasks/task_e_68844db911a08331b44e918881975d70