### PR TITLE
Fix list view root element

### DIFF
--- a/custom_addons/dgii_ncf_manager/__manifest__.py
+++ b/custom_addons/dgii_ncf_manager/__manifest__.py
@@ -6,8 +6,7 @@
     'author': 'Your Company',
     'license': 'LGPL-3',
     'depends': [
-        'account',
-        'custom_erp'
+        'account'
     ],
     'data': [
         'security/dgii_ncf_security.xml',
@@ -20,5 +19,5 @@
         'data/cron.xml',
     ],
     'installable': True,
-    'application': False,
+    'application': True,
 }

--- a/custom_addons/dgii_ncf_manager/views/account_journal_views.xml
+++ b/custom_addons/dgii_ncf_manager/views/account_journal_views.xml
@@ -7,7 +7,7 @@
         <field name="arch" type="xml">
             <xpath expr="//group/group" position="inside">
                 <field name="usar_ncf"/>
-                <field name="default_ncf_type" attrs="{'invisible': [('usar_ncf','=',False)]}"/>
+                <field name="default_ncf_type" modifiers="{'invisible': [('usar_ncf', '=', False)]}"/>
             </xpath>
         </field>
     </record>

--- a/custom_addons/dgii_ncf_manager/views/ncf_range_views.xml
+++ b/custom_addons/dgii_ncf_manager/views/ncf_range_views.xml
@@ -3,8 +3,9 @@
     <record id="view_ncf_range_tree" model="ir.ui.view">
         <field name="name">ncf.range.tree</field>
         <field name="model">ncf.range</field>
+        <field name="type">list</field>
         <field name="arch" type="xml">
-            <tree>
+            <list>
                 <field name="name"/>
                 <field name="ncf_type"/>
                 <field name="sequence_start"/>
@@ -12,7 +13,7 @@
                 <field name="current_ncf"/>
                 <field name="expiration_date"/>
                 <field name="state"/>
-            </tree>
+            </list>
         </field>
     </record>
 


### PR DESCRIPTION
## Summary
- use `<list>` as the root element of the NCF range list view
- make `dgii_ncf_manager` appear in Apps by removing custom_erp dependency
- adapt `account_journal` form view to the new `modifiers` attribute

## Testing
- `python3 -m compileall custom_addons/dgii_ncf_manager`
- `pytest -q custom_addons/dgii_ncf_manager/tests/test_ncf_range.py` *(fails: ModuleNotFoundError: No module named 'odoo')*

------
https://chatgpt.com/codex/tasks/task_e_68844db911a08331b44e918881975d70